### PR TITLE
chore: update truecharts repository

### DIFF
--- a/repositories/helm/truecharts.yaml
+++ b/repositories/helm/truecharts.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   type: oci
   interval: 5m
-  url: oci://tccr.io/truecharts
+  url: oci://oci.trueforge.org/truecharts


### PR DESCRIPTION
## Summary
- update TrueCharts HelmRepository URL to new oci.trueforge.org domain

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 120}}}' repositories/helm/truecharts.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68bef539a7cc8321a3f8175227205b98