### PR TITLE
chore: migrate to trueforge registry

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
     "name": "ClusterTool Cluster",
-    "image": "tccr.io/tccr/devcontainer:v1.0.4@sha256:feb7265bc7e163946fed132916fe83e47a938c63c678277eb771f05901379fe3",
-    "initializeCommand": "docker pull tccr.io/tccr/devcontainer:v1.0.4",
+    "image": "oci.trueforge.org/tccr/devcontainer:v1.0.4@sha256:feb7265bc7e163946fed132916fe83e47a938c63c678277eb771f05901379fe3",
+    "initializeCommand": "docker pull oci.trueforge.org/tccr/devcontainer:v1.0.4",
     "postCreateCommand": {
       "setup": "bash ${containerWorkspaceFolder}/.devcontainer/postCreateCommand.sh"
     },

--- a/repositories/helm/truecharts.yaml
+++ b/repositories/helm/truecharts.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   type: oci
   interval: 5m
-  url: oci://tccr.io/truecharts
+  url: oci://oci.trueforge.org/truecharts


### PR DESCRIPTION
## Summary
- update TrueCharts HelmRepository URL to new oci.trueforge.org domain
- switch devcontainer image and initialize command to new registry

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 120}}}' repositories/helm/truecharts.yaml`
- `jq empty .devcontainer/devcontainer.json`


------
https://chatgpt.com/codex/tasks/task_e_68bef539a7cc8321a3f8175227205b98